### PR TITLE
feat: 문서 메타데이터 수정 API 추가 + 활동 로그 action 구분

### DIFF
--- a/api/drive.py
+++ b/api/drive.py
@@ -117,6 +117,14 @@ class DocChatRequest(BaseModel):
     question: str
     user_id: str = ""
 
+class UpdateMetadataRequest(BaseModel):
+    """메타데이터 수정 요청"""
+    user_id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    visibility: Optional[str] = None
+    tags: Optional[List[str]] = None
+
 class DocChatResponse(BaseModel):
     """문서별 채팅 응답"""
     success: bool
@@ -268,6 +276,34 @@ async def get_document(doc_id: str):
         raise
     except Exception as e:
         raise HTTPException(500, f"문서 조회 실패: {str(e)}")
+
+
+@router.patch("/documents/{doc_id}")
+async def update_document_metadata(doc_id: str, request: UpdateMetadataRequest):
+    """
+    문서 메타데이터 수정 API
+    
+    수정 가능: 제목, 설명, 공개범위, 태그
+    재임베딩 불필요 (메타데이터만 변경)
+    """
+    # 최소 1개 필드는 있어야 함
+    if all(v is None for v in [request.title, request.description, request.visibility, request.tags]):
+        raise HTTPException(400, "수정할 필드가 없습니다")
+    
+    try:
+        result = await drive_service.update_metadata(
+            doc_id=doc_id,
+            user_id=request.user_id,
+            title=request.title,
+            description=request.description,
+            visibility=request.visibility,
+            tags=request.tags
+        )
+        return result
+    except ValueError as e:
+        raise HTTPException(404, str(e))
+    except Exception as e:
+        raise HTTPException(500, f"메타데이터 수정 실패: {str(e)}")
 
 
 @router.delete("/documents/{doc_id}")

--- a/application/usecases/ai_drive/service.py
+++ b/application/usecases/ai_drive/service.py
@@ -239,6 +239,40 @@ class AIDriveService:
         
         return True
     
+    async def update_metadata(
+        self,
+        doc_id: str,
+        user_id: str,
+        title: str = None,
+        description: str = None,
+        visibility: str = None,
+        tags: List[str] = None
+    ) -> Dict[str, Any]:
+        """
+        문서 메타데이터 수정 (Facade)
+        
+        수정 가능: 제목, 설명, 공개범위, 태그
+        재임베딩/재처리 불필요 (메타데이터만 변경)
+        """
+        # 문서 존재 확인
+        doc = self.db_client.get_document(doc_id)
+        if not doc:
+            raise ValueError("문서를 찾을 수 없습니다")
+        
+        # 메타데이터 수정
+        result = self.db_client.update_document_metadata(
+            doc_id=doc_id,
+            title=title,
+            description=description,
+            visibility=visibility,
+            tags=tags
+        )
+        
+        if not result["success"]:
+            raise ValueError(result.get("error", "메타데이터 수정 실패"))
+        
+        return result
+    
     async def chat_with_document(self, doc_id: str, request) -> Dict[str, Any]:
         """
         문서 채팅 (Facade)

--- a/services/ai_drive/db/postgres_client.py
+++ b/services/ai_drive/db/postgres_client.py
@@ -262,6 +262,75 @@ class PostgresClient:
         finally:
             session.close()
 
+    def update_document_metadata(
+        self,
+        doc_id: str,
+        title: str = None,
+        description: str = None,
+        visibility: str = None,
+        tags: List[str] = None
+    ) -> Dict[str, Any]:
+        """
+        문서 메타데이터 수정 (제목, 설명, 공개범위, 태그)
+        
+        Args:
+            doc_id: 문서 ID
+            title: 변경할 제목 (None이면 변경 안 함)
+            description: 변경할 설명
+            visibility: 변경할 공개범위
+            tags: 변경할 태그
+            
+        Returns:
+            {"success": True, "changed_fields": ["title", "visibility"]}
+        """
+        session = self.Session()
+        
+        try:
+            doc = session.query(Document).filter(
+                Document.doc_id == uuid.UUID(doc_id),
+                Document.is_latest == True
+            ).first()
+            
+            if not doc:
+                return {"success": False, "error": "문서를 찾을 수 없습니다"}
+            
+            changed_fields = []
+            
+            if title is not None and title != doc.title:
+                doc.title = title
+                changed_fields.append("title")
+            
+            if description is not None and description != doc.description:
+                doc.description = description
+                changed_fields.append("description")
+            
+            if visibility is not None and visibility != doc.visibility:
+                doc.visibility = visibility
+                changed_fields.append("visibility")
+            
+            if tags is not None and tags != doc.tags:
+                doc.tags = tags
+                changed_fields.append("tags")
+            
+            if changed_fields:
+                doc.modified_at = datetime.utcnow()
+                session.commit()
+                print(f"✓ 메타데이터 수정: {doc_id} → {changed_fields}")
+            
+            return {
+                "success": True,
+                "changed_fields": changed_fields,
+                "doc_id": str(doc.doc_id),
+                "title": doc.title,
+                "description": doc.description,
+                "visibility": doc.visibility,
+                "tags": doc.tags,
+                "modified_at": doc.modified_at.isoformat()
+            }
+            
+        finally:
+            session.close()
+
     def list_documents(
         self,
         creator_department: str = None,

--- a/services/ai_drive/pipeline.py
+++ b/services/ai_drive/pipeline.py
@@ -189,14 +189,16 @@ class DocumentPipeline:
             # 활동 로그 기록
             self.postgres_client.log_activity(
                 user_id=creator_id,
-                action="upload",
+                action="update_file" if version > 1 else "upload",
                 doc_id=doc_id,
                 success=True,
                 duration_ms=duration_ms,
                 details={
                     "filename": filename,
                     "file_type": file_type,
-                    "chunk_count": len(chunks)
+                    "chunk_count": len(chunks),
+                    "version": version,
+                    "parent_doc_id": parent_doc_id
                 }
             )
             


### PR DESCRIPTION
[메타데이터 수정 API]
- PATCH /documents/{doc_id} 엔드포인트 추가 (api/drive.py)
- 수정 가능 필드: title, description, visibility, tags
- 재임베딩/재처리 불필요 (메타데이터만 변경)
- 빈 요청 거부 (400), 문서 미존재 거부 (404)

[3계층 구현]
- api/drive.py: UpdateMetadataRequest 모델 + PATCH 엔드포인트
- application/service.py: update_metadata() Facade 메서드
- postgres_client.py: update_document_metadata() DB 메서드
  - is_latest=True인 문서만 대상
  - changed_fields 추적하여 리턴
  - modified_at 자동 갱신

[활동 로그 action 구분]
- pipeline.py process_file_upload() 활동 로그 수정
- version=1 → action='upload' (신규)
- version>1 → action='update_file' (버전업)
- details에 version, parent_doc_id 추가